### PR TITLE
feature/PaymentDetails

### DIFF
--- a/components/composite/StepPayment/PaymentDetails/index.tsx
+++ b/components/composite/StepPayment/PaymentDetails/index.tsx
@@ -25,7 +25,7 @@ export const PaymentDetails: React.FC<Props> = ({ hasEditButton = false }) => {
 
   const { paymentMethod } = appCtx
 
-  const isCreditCard = () => {
+  const isCreditCard = async () => {
     return paymentMethod?.paymentSourceType === "stripe_payments"
   }
 


### PR DESCRIPTION
Ho aggiunto async a isCreditCard perchè a volte se cambi veloce da Wire Transfer a Credit Card non ti si caricano i dettagli della carta salvata già nel wallet perchè paymentMethod dentro la condizione isCreditCard da come risultato undefined