### PR TITLE
Add `frequency` to line items on order summary

### DIFF
--- a/components/composite/OrderSummary/LineItemTypes/index.tsx
+++ b/components/composite/OrderSummary/LineItemTypes/index.tsx
@@ -8,8 +8,15 @@ import LineItemImage from "@commercelayer/react-components/line_items/LineItemIm
 import LineItemName from "@commercelayer/react-components/line_items/LineItemName"
 import LineItemOption from "@commercelayer/react-components/line_items/LineItemOption"
 import LineItemQuantity from "@commercelayer/react-components/line_items/LineItemQuantity"
+import cronParser from "cron-parser"
+import cronstrue from "cronstrue"
 import { useTranslation } from "next-i18next"
 import React from "react"
+import "cronstrue/locales/en"
+import "cronstrue/locales/it"
+import "cronstrue/locales/de"
+
+import { RepeatIcon } from "../RepeatIcon"
 
 import { FlexContainer } from "components/ui/FlexContainer"
 
@@ -33,7 +40,7 @@ const CODE_LOOKUP: { [k: string]: "sku_code" | "bundle_code" | undefined } = {
 }
 
 export const LineItemTypes: React.FC<Props> = ({ type }) => {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   return (
     <LineItem type={type}>
       <LineItemWrapper data-testid={`line-items-${type}`}>
@@ -50,7 +57,7 @@ export const LineItemTypes: React.FC<Props> = ({ type }) => {
           <StyledLineItemOptions showAll showName={true} className="options">
             <LineItemOption />
           </StyledLineItemOptions>
-          <FlexContainer className="justify-between mt-2">
+          <FlexContainer className="flex-col justify-between mt-2 lg:flex-row">
             <LineItemQty>
               <LineItemQuantity>
                 {(props) => (
@@ -63,15 +70,29 @@ export const LineItemTypes: React.FC<Props> = ({ type }) => {
             </LineItemQty>
             <LineItemField attribute="frequency">
               {/*  @ts-expect-error typing on attribute */}
-              {({ attributeValue }) =>
-                attributeValue ? (
+              {({ attributeValue }) => {
+                if (!attributeValue) {
+                  return null
+                }
+                let isCronValid = true
+                try {
+                  cronParser.parseExpression(attributeValue as string)
+                } catch (e) {
+                  isCronValid = false
+                }
+                const frequency = isCronValid
+                  ? cronstrue.toString(attributeValue as string, {
+                      locale: i18n.language,
+                    })
+                  : t(`orderRecap.frequency.${attributeValue}`)
+
+                return (
                   <LineItemFrequency>
-                    {(attributeValue as string)[0].toUpperCase() +
-                      (attributeValue as string).slice(1)}{" "}
-                    subscription
+                    <RepeatIcon />
+                    {frequency}
                   </LineItemFrequency>
-                ) : null
-              }
+                )
+              }}
             </LineItemField>
           </FlexContainer>
         </LineItemDescription>

--- a/components/composite/OrderSummary/LineItemTypes/index.tsx
+++ b/components/composite/OrderSummary/LineItemTypes/index.tsx
@@ -87,7 +87,7 @@ export const LineItemTypes: React.FC<Props> = ({ type }) => {
                   : t(`orderRecap.frequency.${attributeValue}`)
 
                 return (
-                  <LineItemFrequency>
+                  <LineItemFrequency data-testid="line-items-frequency">
                     <RepeatIcon />
                     {frequency}
                   </LineItemFrequency>

--- a/components/composite/OrderSummary/LineItemTypes/index.tsx
+++ b/components/composite/OrderSummary/LineItemTypes/index.tsx
@@ -1,3 +1,4 @@
+import { LineItemField } from "@commercelayer/react-components"
 import {
   LineItem,
   TLineItem,
@@ -10,9 +11,12 @@ import LineItemQuantity from "@commercelayer/react-components/line_items/LineIte
 import { useTranslation } from "next-i18next"
 import React from "react"
 
+import { FlexContainer } from "components/ui/FlexContainer"
+
 import {
   LineItemDescription,
   LineItemQty,
+  LineItemFrequency,
   LineItemTitle,
   LineItemWrapper,
   StyledLineItemSkuCode,
@@ -46,16 +50,30 @@ export const LineItemTypes: React.FC<Props> = ({ type }) => {
           <StyledLineItemOptions showAll showName={true} className="options">
             <LineItemOption />
           </StyledLineItemOptions>
-          <LineItemQty>
-            <LineItemQuantity>
-              {(props) => (
-                <>
-                  {!!props.quantity &&
-                    t("orderRecap.quantity", { count: props.quantity })}
-                </>
-              )}
-            </LineItemQuantity>
-          </LineItemQty>
+          <FlexContainer className="justify-between mt-2">
+            <LineItemQty>
+              <LineItemQuantity>
+                {(props) => (
+                  <>
+                    {!!props.quantity &&
+                      t("orderRecap.quantity", { count: props.quantity })}
+                  </>
+                )}
+              </LineItemQuantity>
+            </LineItemQty>
+            <LineItemField attribute="frequency">
+              {/*  @ts-expect-error typing on attribute */}
+              {({ attributeValue }) =>
+                attributeValue ? (
+                  <LineItemFrequency>
+                    {(attributeValue as string)[0].toUpperCase() +
+                      (attributeValue as string).slice(1)}{" "}
+                    subscription
+                  </LineItemFrequency>
+                ) : null
+              }
+            </LineItemField>
+          </FlexContainer>
         </LineItemDescription>
       </LineItemWrapper>
     </LineItem>

--- a/components/composite/OrderSummary/LineItemTypes/styled.tsx
+++ b/components/composite/OrderSummary/LineItemTypes/styled.tsx
@@ -16,7 +16,7 @@ export const LineItemQty = styled.div`
   ${tw`text-xs bg-gray-100 max-w-max py-1 px-2.5 rounded lowercase text-gray-500 font-bold first-letter:uppercase`}
 `
 export const LineItemFrequency = styled(LineItemQty)`
-  ${tw`bg-white border border-primary text-primary `}
+  ${tw`mt-2 flex bg-white border border-primary text-primary lg:mt-0`}
 `
 
 export const StyledLineItemSkuCode = styled(LineItemCode)`

--- a/components/composite/OrderSummary/LineItemTypes/styled.tsx
+++ b/components/composite/OrderSummary/LineItemTypes/styled.tsx
@@ -13,8 +13,12 @@ export const LineItemTitle = styled.div`
   ${tw`flex justify-between text-black`}
 `
 export const LineItemQty = styled.div`
-  ${tw`text-xs mt-2 bg-gray-200 max-w-max py-1 px-2.5 rounded-full tracking-wider text-gray-400 font-bold`}
+  ${tw`text-xs bg-gray-100 max-w-max py-1 px-2.5 rounded lowercase text-gray-500 font-bold first-letter:uppercase`}
 `
+export const LineItemFrequency = styled(LineItemQty)`
+  ${tw`bg-white border border-primary text-primary `}
+`
+
 export const StyledLineItemSkuCode = styled(LineItemCode)`
   ${tw`text-xxs uppercase text-gray-400 font-bold mb-1`}
 `

--- a/components/composite/OrderSummary/RepeatIcon.tsx
+++ b/components/composite/OrderSummary/RepeatIcon.tsx
@@ -1,0 +1,20 @@
+import styled from "styled-components"
+import tw from "twin.macro"
+
+export const RepeatIcon: React.FC = () => {
+  return (
+    <Svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="currentColor"
+      viewBox="0 0 256 256"
+    >
+      <path d="M20,128A76.08,76.08,0,0,1,96,52h99l-3.52-3.51a12,12,0,1,1,17-17l24,24a12,12,0,0,1,0,17l-24,24a12,12,0,0,1-17-17L195,76H96a52.06,52.06,0,0,0-52,52,12,12,0,0,1-24,0Zm204-12a12,12,0,0,0-12,12,52.06,52.06,0,0,1-52,52H61l3.52-3.51a12,12,0,1,0-17-17l-24,24a12,12,0,0,0,0,17l24,24a12,12,0,1,0,17-17L61,204h99a76.08,76.08,0,0,0,76-76A12,12,0,0,0,224,116Z"></path>{" "}
+    </Svg>
+  )
+}
+
+const Svg = styled.svg`
+  ${tw`mr-1.5`}
+`

--- a/components/composite/StepPayment/styled.tsx
+++ b/components/composite/StepPayment/styled.tsx
@@ -68,7 +68,7 @@ export const PaymentItemTitle = styled.h5`
   ${tw`text-sm font-bold`}
 `
 export const ShippingLineItemQty = styled.p`
-  ${tw`text-xs text-gray-400 uppercase pt-1`}
+  ${tw`text-lg text-gray-500 lowercase pt-1`}
 `
 export const WalletCheckbox = styled.input`
   ${CheckCss}

--- a/components/composite/StepShipping/styled.tsx
+++ b/components/composite/StepShipping/styled.tsx
@@ -38,7 +38,7 @@ export const ShippingLineItemTitle = styled.h5`
   ${tw`text-black text-sm font-bold`}
 `
 export const ShippingLineItemQty = styled.p`
-  ${tw`text-xs text-gray-400 uppercase pt-1`}
+  ${tw`text-xs font-semibold text-gray-400 lowercase pt-1 first-letter:uppercase`}
 `
 export const StyledShippingMethodRadioButton = styled(
   ShippingMethodRadioButton

--- a/components/ui/FlexContainer/index.tsx
+++ b/components/ui/FlexContainer/index.tsx
@@ -11,5 +11,5 @@ export const FlexContainer: React.FC<Props> = ({ children, className }) => (
 )
 
 const Wrapper = styled.div`
-  ${tw`flex justify-start`}
+  ${tw`flex`}
 `

--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
     "async-retry": "^1.3.3",
     "autoprefixer": "^10.4.14",
     "classnames": "^2.3.2",
+    "cron-parser": "^4.9.0",
+    "cronstrue": "^2.31.0",
     "dotenv": "^16.3.1",
     "i18next": "^21.10.0",
     "jsonwebtoken": "^9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,12 @@ dependencies:
   classnames:
     specifier: ^2.3.2
     version: 2.3.2
+  cron-parser:
+    specifier: ^4.9.0
+    version: 4.9.0
+  cronstrue:
+    specifier: ^2.31.0
+    version: 2.31.0
   dotenv:
     specifier: ^16.3.1
     version: 16.3.1
@@ -2441,6 +2447,18 @@ packages:
     resolution: {integrity: sha512-CpNFuLxiPFxuZqhSKml3M+t0K/484pMAnfYWH14JoD7OZMnmC0Lmo+P7JX9SobqFpRoo7ifA18kOHdxJywYPEA==}
     dev: false
 
+  /cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      luxon: 3.4.1
+    dev: false
+
+  /cronstrue@2.31.0:
+    resolution: {integrity: sha512-A1cyfGyLSRdvT9MNn/pggoCTlvxnJyiCUItU9XHSXk89ZyK2YY9q9q7Rf4j8NhV9YwN1BjB0wimZlvKYb/9Bwg==}
+    hasBin: true
+    dev: false
+
   /cross-spawn@6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
     engines: {node: '>=4.8'}
@@ -4238,6 +4256,7 @@ packages:
   /iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       safer-buffer: 2.1.2
     dev: true
@@ -4998,6 +5017,11 @@ packages:
     resolution: {integrity: sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==}
     engines: {node: 14 || >=16.14}
     dev: true
+
+  /luxon@3.4.1:
+    resolution: {integrity: sha512-2USspxOCXWGIKHwuQ9XElxPPYrDOJHDQ5DQ870CoD+CxJbBnRDIBCfhioUJJjct7BKOy80Ia8cVstIcIMb/0+Q==}
+    engines: {node: '>=12'}
+    dev: false
 
   /make-fetch-happen@11.1.1:
     resolution: {integrity: sha512-rLWS7GCSTcEujjVBs2YqG7Y4643u8ucvCJeSRqiLYhesrDuzeuFIk37xREzAsfQaqzl8b9rNCE4m6J8tvX4Q8w==}

--- a/public/static/locales/de/common.json
+++ b/public/static/locales/de/common.json
@@ -51,7 +51,20 @@
         "subtotal_amount": "Zwischensumme",
         "total_amount": "Summe",
         "notSet": "Zu berechnen",
-        "returnToCart": "Zurück zum Warenkorb"
+        "returnToCart": "Zurück zum Warenkorb",
+        "frequency.hourly": "Hourly",
+        "frequency.daily": "Daily",
+        "frequency.weekly": "Weekly",
+        "frequency.monthly": "Monthly",
+        "frequency.two-months": "Every two months",
+        "frequency.two-month": "Every two months",
+        "frequency.three-months": "Every three months",
+        "frequency.three-month": "Every three months",
+        "frequency.four-months": "Every four months",
+        "frequency.four-month": "Every four months",
+        "frequency.six-months": "Every six months",
+        "frequency.six-month": "Every six months",
+        "frequency.yearly": "Yearly"
     },
   
     "stepCustomer": {

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -50,7 +50,20 @@
         "subtotal_amount": "Subtotal",
         "total_amount": "Total",
         "notSet": "To be calculated",
-        "returnToCart": "Return to cart"
+        "returnToCart": "Return to cart",
+        "frequency.hourly": "Hourly",
+        "frequency.daily": "Daily",
+        "frequency.weekly": "Weekly",
+        "frequency.monthly": "Monthly",
+        "frequency.two-months": "Every two months",
+        "frequency.two-month": "Every two months",
+        "frequency.three-months": "Every three months",
+        "frequency.three-month": "Every three months",
+        "frequency.four-months": "Every four months",
+        "frequency.four-month": "Every four months",
+        "frequency.six-months": "Every six months",
+        "frequency.six-month": "Every six months",
+        "frequency.yearly": "Yearly"
     },
 
     "stepCustomer": {

--- a/public/static/locales/it/common.json
+++ b/public/static/locales/it/common.json
@@ -51,7 +51,20 @@
         "subtotal_amount": "Subtotale",
         "total_amount": "Totale",
         "notSet": "Da calcolare",
-        "returnToCart": "Ritorna al carrello"
+        "returnToCart": "Ritorna al carrello",
+        "frequency.hourly": "Orario",
+        "frequency.daily": "Giornaliero",
+        "frequency.weekly": "Settimanale",
+        "frequency.monthly": "Mensile",
+        "frequency.two-months": "Ogni due mesi",
+        "frequency.two-month": "Ogni due mesi",
+        "frequency.three-months": "Ogni tre mesi",
+        "frequency.three-month": "Ogni tre mesi",
+        "frequency.four-months": "Ogni quattro mesi",
+        "frequency.four-month": "Ogni quattro mesi",
+        "frequency.six-months": "Ogni sei mesi",
+        "frequency.six-month": "Ogni sei mesi",
+        "frequency.yearly": "Annuale"
     },
 
     "stepCustomer": {

--- a/specs/e2e/order-summary.spec.ts
+++ b/specs/e2e/order-summary.spec.ts
@@ -448,3 +448,42 @@ test.describe("count buying gift card", () => {
     await checkoutPage.checkLineItemsCount("Your shopping cart contains 1 item")
   })
 })
+
+test.describe("line item with frequency", () => {
+  test.use({
+    defaultParams: {
+      order: "with-items",
+      lineItemsAttributes: [
+        {
+          sku_code: "TSHIRTMMFFFFFF000000XLXX",
+          quantity: 1,
+          frequency: "monthly",
+        },
+      ],
+    },
+  })
+
+  test("should show the monthly frequency", async ({ checkoutPage }) => {
+    await checkoutPage.checkOrderSummary("Order Summary")
+    await checkoutPage.checkLineItemFrequency("Monthly")
+  })
+})
+
+test.describe("line item without frequency", () => {
+  test.use({
+    defaultParams: {
+      order: "with-items",
+      lineItemsAttributes: [
+        {
+          sku_code: "TSHIRTMMFFFFFF000000XLXX",
+          quantity: 1,
+        },
+      ],
+    },
+  })
+
+  test("should show the monthly frequency", async ({ checkoutPage }) => {
+    await checkoutPage.checkOrderSummary("Order Summary")
+    await checkoutPage.checkLineItemFrequency()
+  })
+})

--- a/specs/fixtures/CheckoutPage.ts
+++ b/specs/fixtures/CheckoutPage.ts
@@ -723,6 +723,7 @@ export class CheckoutPage {
             await pagePromise.getByLabel("Kontonummer").fill("12345678")
             await pagePromise.getByLabel("PIN").click()
             await pagePromise.getByLabel("PIN").fill("1234")
+            await pagePromise.waitForTimeout(2000)
             await pagePromise.getByRole("button", { name: "Weiter" }).click()
             await pagePromise.getByLabel("TAN").click()
             await pagePromise.getByLabel("TAN").fill("12345")
@@ -831,7 +832,6 @@ export class CheckoutPage {
 
               // await klarnaIframe.getByTestId("kaf-button").click()
               // await this.page.waitForTimeout(2000)
-
               await klarnaIframe.getByTestId("pick-plan").click()
               await klarnaIframe
                 .locator("label")
@@ -843,6 +843,16 @@ export class CheckoutPage {
                 .nth(1)
                 .click()
               await klarnaIframe.getByTestId("confirm-and-pay").click()
+
+              const iban = klarnaIframe.getByRole("textbox", {
+                name: "IBAN übermitteln",
+              })
+
+              if (await iban.isVisible()) {
+                iban.click()
+                iban.fill("DE91100000000123456789")
+                klarnaIframe.getByRole("button", { name: "Bestätigen" }).click()
+              }
             }
             break
           }

--- a/specs/fixtures/CheckoutPage.ts
+++ b/specs/fixtures/CheckoutPage.ts
@@ -511,7 +511,7 @@ export class CheckoutPage {
 
   async checkShippingSummary(text?: string) {
     if (text === undefined) {
-      const element = await this.page.getByTestId("shipping-amount")
+      const element = this.page.getByTestId("shipping-amount")
       await expect(element).toHaveCount(0)
     } else {
       await this.page
@@ -522,8 +522,17 @@ export class CheckoutPage {
   }
 
   async checkLineItemsCount(text: string) {
-    const element = await this.page.locator(`[data-testid=items-count]`)
+    const element = this.page.locator(`[data-testid=items-count]`)
     await expect(element).toHaveText(text)
+  }
+
+  async checkLineItemFrequency(text?: string) {
+    const element = this.page.locator(`[data-testid=line-items-frequency]`)
+    if (text) {
+      await expect(element).toContainText(text)
+    } else {
+      expect(element).toBeHidden()
+    }
   }
 
   async checkPaymentRecap(text: string) {

--- a/specs/fixtures/CheckoutPage.ts
+++ b/specs/fixtures/CheckoutPage.ts
@@ -821,7 +821,10 @@ export class CheckoutPage {
               await klarnaIframe.locator("input#otp_field").type("123456")
               await this.page.waitForTimeout(1000)
 
-              // await klarnaIframe.getByTestId("kaf-button").click()
+              const emailButton = klarnaIframe.getByTestId("kaf-button")
+              if (await emailButton.isVisible()) {
+                emailButton.click()
+              }
 
               // await klarnaIframe
               //   .locator("input#addressCollector-date_of_birth")

--- a/specs/fixtures/tokenizedPage.ts
+++ b/specs/fixtures/tokenizedPage.ts
@@ -27,6 +27,7 @@ type OrderType =
 interface BaseLineItemObject {
   quantity: number
   inventory?: number
+  frequency?: string
   sku_options?: Array<Record<string, string | object>>
 }
 


### PR DESCRIPTION
Closes #335 

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This PR will display the `frequency` attribute if present on the line item. 

<!-- Briefly describe what your PR does -->

## How to test

The PR can be tested creating an order with a line item with frequency. Frequency should be one of the available frequency on the market.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
