### PR TITLE
Improve checkout load time making two setup calls in parallel

### DIFF
--- a/utils/getSettings.ts
+++ b/utils/getSettings.ts
@@ -176,7 +176,10 @@ export const getSettings = async ({
     domain,
   })
 
-  const organizationResource = await getOrganization(cl)
+  const [organizationResource, orderResource] = await Promise.all([
+    getOrganization(cl),
+    getOrder(cl, orderId),
+  ])
 
   const organization = organizationResource?.object
 
@@ -185,7 +188,6 @@ export const getSettings = async ({
     return invalidateCheckout(true)
   }
 
-  const orderResource = await getOrder(cl, orderId)
   const order = orderResource?.object
 
   if (!orderResource?.success || !order?.id) {


### PR DESCRIPTION
Closes #374 

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This PR will load `order` and `organization` in parallel and wait for them before deciding if the token can read the organization and the order being valid to open the checkout.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
