### PR TITLE
Improve GTM performances removing calls to Commerce Layer

### DIFF
--- a/components/composite/Checkout/index.tsx
+++ b/components/composite/Checkout/index.tsx
@@ -27,6 +27,7 @@ import {
 } from "components/composite/StepShipping"
 import { AccordionProvider } from "components/data/AccordionProvider"
 import { AppContext } from "components/data/AppProvider"
+import { GTMProvider } from "components/data/GTMProvider"
 import { useActiveStep } from "components/hooks/useActiveStep"
 import { LayoutDefault } from "components/layouts/LayoutDefault"
 import { Accordion, AccordionItem } from "components/ui/Accordion"
@@ -42,6 +43,7 @@ interface Props {
   supportPhone: NullableType<string>
   termsUrl: NullableType<string>
   privacyUrl: NullableType<string>
+  gtmId: NullableType<string>
 }
 
 const Checkout: React.FC<Props> = ({
@@ -53,6 +55,7 @@ const Checkout: React.FC<Props> = ({
   supportPhone,
   termsUrl,
   privacyUrl,
+  gtmId,
 }) => {
   const ctx = useContext(AppContext)
 
@@ -226,7 +229,9 @@ const Checkout: React.FC<Props> = ({
 
   return (
     <OrderContainer orderId={ctx.orderId} fetchOrder={ctx.getOrder}>
-      {ctx.isComplete ? renderComplete() : renderSteps()}
+      <GTMProvider gtmId={gtmId}>
+        {ctx.isComplete ? renderComplete() : renderSteps()}
+      </GTMProvider>
     </OrderContainer>
   )
 }

--- a/components/composite/CheckoutContainer/index.tsx
+++ b/components/composite/CheckoutContainer/index.tsx
@@ -3,7 +3,6 @@ import CommerceLayer from "@commercelayer/react-components/auth/CommerceLayer"
 import { CheckoutHead } from "components/composite/CheckoutTitle"
 import { AppProvider } from "components/data/AppProvider"
 import GlobalStylesProvider from "components/data/GlobalStylesProvider"
-import { GTMProvider } from "components/data/GTMProvider"
 import hex2hsl from "components/utils/hex2hsl"
 
 interface Props {
@@ -30,7 +29,7 @@ const CheckoutContainer = ({ settings, children }: Props): JSX.Element => {
           slug={settings.slug}
           domain={settings.domain}
         >
-          <GTMProvider gtmId={settings.gtmId}>{children}</GTMProvider>
+          {children}
         </AppProvider>
       </CommerceLayer>
     </div>

--- a/components/composite/StepShipping/index.tsx
+++ b/components/composite/StepShipping/index.tsx
@@ -153,19 +153,19 @@ export const StepShipping: React.FC<Props> = () => {
   const handleSave = async () => {
     setIsLocalLoader(true)
 
-    saveShipments()
+    const updatedOrder = await saveShipments()
 
     setIsLocalLoader(false)
     if (gtmCtx?.fireAddShippingInfo) {
-      await gtmCtx.fireAddShippingInfo()
+      await gtmCtx.fireAddShippingInfo(updatedOrder)
     }
   }
 
   const autoSelectCallback = async (order?: Order) => {
+    const updatedOrder = await appCtx.autoSelectShippingMethod(order)
     if (gtmCtx?.fireAddShippingInfo) {
-      await gtmCtx.fireAddShippingInfo()
+      await gtmCtx.fireAddShippingInfo(updatedOrder)
     }
-    await appCtx.autoSelectShippingMethod(order)
   }
 
   return (

--- a/components/data/AppProvider/index.tsx
+++ b/components/data/AppProvider/index.tsx
@@ -5,7 +5,7 @@ import {
   type Order,
 } from "@commercelayer/sdk"
 import { changeLanguage } from "i18next"
-import { createContext, useEffect, useReducer, useRef } from "react"
+import { createContext, useEffect, useReducer, useRef, useState } from "react"
 
 import { ActionType, reducer } from "components/data/AppProvider/reducer"
 import {
@@ -19,6 +19,7 @@ import {
 export interface AppProviderData extends FetchOrderByIdResponse {
   isLoading: boolean
   orderId: string
+  order: NullableType<Order>
   accessToken: string
   isGuest: boolean
   slug: string
@@ -29,7 +30,7 @@ export interface AppProviderData extends FetchOrderByIdResponse {
   setCustomerEmail: (email: string) => void
   setAddresses: (order?: Order) => Promise<void>
   setCouponOrGiftCard: () => Promise<void>
-  saveShipments: () => void
+  saveShipments: () => Promise<Order>
   placeOrder: (order?: Order) => Promise<void>
   setPayment: (params: { payment?: PaymentMethod; order?: Order }) => void
   selectShipment: (params: {
@@ -39,7 +40,7 @@ export interface AppProviderData extends FetchOrderByIdResponse {
     shipmentId: string
     order?: Order
   }) => Promise<void>
-  autoSelectShippingMethod: (order?: Order) => Promise<void>
+  autoSelectShippingMethod: (order?: Order) => Promise<Order>
 }
 
 export interface AppStateData extends FetchOrderByIdResponse {
@@ -101,6 +102,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({
 }) => {
   const orderRef = useRef<Order>()
   const [state, dispatch] = useReducer(reducer, { ...initialState, isGuest })
+  const [order, setOrder] = useState<NullableType<Order>>()
 
   const cl = CommerceLayer({
     organization: slug,
@@ -110,6 +112,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({
 
   const getOrder = (order: Order) => {
     orderRef.current = order
+    setOrder(order)
   }
 
   const fetchInitialOrder = async (orderId?: string, accessToken?: string) => {
@@ -245,6 +248,8 @@ export const AppProvider: React.FC<AppProviderProps> = ({
         payload: { order: currentOrder, others },
       })
     }, 100)
+
+    return currentOrder
   }
 
   const saveShipments = async () => {
@@ -263,6 +268,8 @@ export const AppProvider: React.FC<AppProviderProps> = ({
         payload: { order: currentOrder, others },
       })
     }, 100)
+
+    return currentOrder
   }
 
   const setPayment = async (params: {
@@ -311,6 +318,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({
       value={{
         ...state,
         orderId,
+        order,
         accessToken,
         isGuest,
         slug,

--- a/components/data/GTMProvider/index.tsx
+++ b/components/data/GTMProvider/index.tsx
@@ -1,5 +1,5 @@
-import { CommerceLayer, LineItem } from "@commercelayer/sdk"
-import { createContext, useEffect, useContext } from "react"
+import { LineItem, Order } from "@commercelayer/sdk"
+import { createContext, useEffect, useContext, useRef } from "react"
 import TagManager from "react-gtm-module"
 
 import { AppContext } from "components/data/AppProvider"
@@ -9,7 +9,7 @@ import { LINE_ITEMS_SHOPPABLE } from "components/utils/constants"
 import { DataLayerItemProps, DataLayerProps } from "./typings"
 
 interface GTMProviderData {
-  fireAddShippingInfo: () => Promise<void>
+  fireAddShippingInfo: (order: Order) => Promise<void>
   fireAddPaymentInfo: () => Promise<void>
   firePurchase: () => Promise<void>
 }
@@ -25,6 +25,8 @@ export const GTMProvider: React.FC<GTMProviderProps> = ({
   children,
   gtmId,
 }) => {
+  const isFirstLoading = useRef(true)
+
   if (!gtmId) {
     return <>{children}</>
   }
@@ -34,20 +36,15 @@ export const GTMProvider: React.FC<GTMProviderProps> = ({
     return <>{children}</>
   }
 
-  const { accessToken, orderId, slug, domain, getOrderFromRef } = ctx
-
-  const cl = CommerceLayer({
-    organization: slug,
-    accessToken,
-    domain,
-  })
+  const { order } = ctx
 
   useEffect(() => {
-    if (gtmId != null) {
+    if (isFirstLoading.current && gtmId != null && order != null) {
+      isFirstLoading.current = false
       TagManager.initialize({ gtmId })
-      fireBeginCheckout()
+      fireBeginCheckout(order)
     }
-  }, [])
+  }, [order])
 
   const pushDataLayer = ({ eventName, dataLayer }: DataLayerProps) => {
     try {
@@ -79,25 +76,8 @@ export const GTMProvider: React.FC<GTMProviderProps> = ({
     }
   }
 
-  const fireBeginCheckout = async () => {
-    const order = await getOrderFromRef()
-    const lineItems = (
-      await cl.orders.retrieve(orderId, {
-        include: ["line_items"],
-        fields: {
-          orders: ["line_items"],
-          line_items: [
-            "sku_code",
-            "bundle_code",
-            "name",
-            "total_amount_float",
-            "currency_code",
-            "quantity",
-            "item_type",
-          ],
-        },
-      })
-    ).line_items?.filter((line_item) => {
+  const fireBeginCheckout = async (order: Order) => {
+    const lineItems = order.line_items?.filter((line_item) => {
       return LINE_ITEMS_SHOPPABLE.includes(line_item.item_type as TypeAccepted)
     })
 
@@ -112,31 +92,8 @@ export const GTMProvider: React.FC<GTMProviderProps> = ({
     })
   }
 
-  const fireAddShippingInfo = async () => {
-    const order = await getOrderFromRef()
-    const shipments = (
-      await cl.orders.retrieve(orderId, {
-        include: [
-          "shipments.shipping_method",
-          "shipments.stock_line_items",
-          "shipments.stock_line_items.line_item",
-        ],
-        fields: {
-          orders: ["shipments"],
-          shipments: ["shipping_method", "stock_line_items"],
-          shipping_method: ["name", "price_amount_for_shipment_float"],
-          stock_line_items: ["line_item"],
-          line_item: [
-            "sku_code",
-            "name",
-            "total_amount_float",
-            "currency_code",
-            "quantity",
-            "item_type",
-          ],
-        },
-      })
-    ).shipments
+  const fireAddShippingInfo = async (order: Order) => {
+    const shipments = order?.shipments
 
     shipments?.forEach(async (shipment) => {
       const lineItems = shipment.stock_line_items?.map(
@@ -159,12 +116,11 @@ export const GTMProvider: React.FC<GTMProviderProps> = ({
   }
 
   const fireAddPaymentInfo = async () => {
-    const order = await getOrderFromRef()
-    const lineItems = order.line_items?.filter((line_item) => {
+    const lineItems = order?.line_items?.filter((line_item) => {
       return LINE_ITEMS_SHOPPABLE.includes(line_item.item_type as TypeAccepted)
     })
 
-    const paymentMethod = order.payment_method
+    const paymentMethod = order?.payment_method
 
     return pushDataLayer({
       eventName: "add_payment_info",
@@ -179,9 +135,7 @@ export const GTMProvider: React.FC<GTMProviderProps> = ({
   }
 
   const firePurchase = async () => {
-    const order = await getOrderFromRef()
-
-    const lineItems = order.line_items?.filter((line_item) => {
+    const lineItems = order?.line_items?.filter((line_item) => {
       return LINE_ITEMS_SHOPPABLE.includes(line_item.item_type as TypeAccepted)
     })
 

--- a/pages/Order.tsx
+++ b/pages/Order.tsx
@@ -44,6 +44,7 @@ const Order: NextPage = () => {
         supportPhone={settings.supportPhone}
         termsUrl={settings.termsUrl}
         privacyUrl={settings.privacyUrl}
+        gtmId={settings.gtmId}
       />
     </DynamicCheckoutContainer>
   )


### PR DESCRIPTION
Closes #376 

## What I did

This PR will remove call from `GTMProvider` and reuse react-components one

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
