### PR TITLE
Consistently fire `add_shipping_info` in Datalayer

### DIFF
--- a/components/data/GTMProvider/index.tsx
+++ b/components/data/GTMProvider/index.tsx
@@ -95,7 +95,7 @@ export const GTMProvider: React.FC<GTMProviderProps> = ({
   const fireAddShippingInfo = async (order: Order) => {
     const shipments = order?.shipments
 
-    shipments?.forEach(async (shipment) => {
+    shipments?.forEach((shipment) => {
       const lineItems = shipment.stock_line_items?.map(
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did
This removes the unnecessary async around an anonymous function in a `forEach`, which led to the datalayer event `add_shipping_info` not being fired consistently.

## How to test
Locally run the application with the tag manager debugger attached to localhost. See whether the `add_shipping_info` fires.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
