### PR TITLE
Toggle for activating business billing address

### DIFF
--- a/components/composite/StepCustomer/BillingAddressFormNew/index.tsx
+++ b/components/composite/StepCustomer/BillingAddressFormNew/index.tsx
@@ -1,21 +1,28 @@
 import { Address } from "@commercelayer/sdk"
 import { useContext } from "react"
+import { useTranslation } from "react-i18next"
 import styled from "styled-components"
 import tw from "twin.macro"
 
 import { ShippingToggleProps } from "components/composite/StepCustomer"
 import { AddressInputGroup } from "components/composite/StepCustomer/AddressInputGroup"
 import { AppContext } from "components/data/AppProvider"
+import { Toggle } from "components/ui/Toggle"
 
 interface Props {
   billingAddress: NullableType<Address>
   openShippingAddress: (props: ShippingToggleProps) => void
+  isBusiness?: boolean
+  toggleIsBusiness?: () => void
 }
 
 export const BillingAddressFormNew: React.FC<Props> = ({
   billingAddress,
   openShippingAddress,
+  isBusiness,
+  toggleIsBusiness,
 }: Props) => {
+  const { t } = useTranslation()
   const appCtx = useContext(AppContext)
 
   if (!appCtx) {
@@ -26,20 +33,38 @@ export const BillingAddressFormNew: React.FC<Props> = ({
 
   return (
     <Wrapper>
-      <Grid>
+      {!isBusiness ? (
+        <Grid>
+          <AddressInputGroup
+            fieldName="billing_address_first_name"
+            resource="billing_address"
+            type="text"
+            value={billingAddress?.first_name || ""}
+          />
+          <AddressInputGroup
+            fieldName="billing_address_last_name"
+            resource="billing_address"
+            type="text"
+            value={billingAddress?.last_name || ""}
+          />
+        </Grid>
+      ) : (
         <AddressInputGroup
-          fieldName="billing_address_first_name"
+          fieldName="billing_address_company"
           resource="billing_address"
           type="text"
-          value={billingAddress?.first_name || ""}
+          value={billingAddress?.company || ""}
         />
-        <AddressInputGroup
-          fieldName="billing_address_last_name"
-          resource="billing_address"
-          type="text"
-          value={billingAddress?.last_name || ""}
-        />
-      </Grid>
+      )}
+      <Toggle
+        disabled={false}
+        data-testid="button-toggle-company-address"
+        data-status={!!isBusiness}
+        label={t(`addressForm.toggle_company_address`)}
+        checked={!!isBusiness}
+        onChange={() => toggleIsBusiness?.()}
+        wrapperClassName="!-mt-6 !border-t-0 border-b mb-5"
+      />
       <AddressInputGroup
         fieldName="billing_address_line_1"
         resource="billing_address"

--- a/components/composite/StepCustomer/CheckoutAddresses.tsx
+++ b/components/composite/StepCustomer/CheckoutAddresses.tsx
@@ -51,6 +51,7 @@ export const CheckoutAddresses: React.FC<Props> = ({
 
   const [shippingAddressFill, setShippingAddressFill] =
     useState<NullableType<Address>>(shippingAddress)
+  const [isBusiness, setIsBusiness] = useState(!!billingAddress?.company)
 
   const handleToggleDifferentAddress = () => {
     return [
@@ -71,7 +72,10 @@ export const CheckoutAddresses: React.FC<Props> = ({
         emailAddress={emailAddress}
         setCustomerEmail={setCustomerEmail}
       />
-      <AddressesContainer shipToDifferentAddress={shipToDifferentAddress}>
+      <AddressesContainer
+        shipToDifferentAddress={shipToDifferentAddress}
+        isBusiness={isBusiness}
+      >
         <div className="mt-4">
           <AddressSectionTitle>
             <>{t(`addressForm.billing_address_title`)}</>
@@ -82,6 +86,8 @@ export const CheckoutAddresses: React.FC<Props> = ({
             <BillingAddressFormNew
               billingAddress={billingAddress}
               openShippingAddress={openShippingAddress}
+              isBusiness={isBusiness}
+              toggleIsBusiness={() => setIsBusiness(!isBusiness)}
             />
           </div>
         </BillingAddressForm>

--- a/components/composite/StepCustomer/CheckoutCustomerAddresses.tsx
+++ b/components/composite/StepCustomer/CheckoutCustomerAddresses.tsx
@@ -87,6 +87,8 @@ export const CheckoutCustomerAddresses: React.FC<Props> = ({
     isUsingNewShippingAddress
   )
 
+  const [isBusiness, setIsBusiness] = useState(!!billingAddress?.company)
+
   useEffect(() => {
     if (shipToDifferentAddress && !hasCustomerAddresses) {
       // If billing and shipping are equivalent, show form but reset it
@@ -149,7 +151,10 @@ export const CheckoutCustomerAddresses: React.FC<Props> = ({
   return (
     <Fragment>
       <AddressSectionEmail readonly emailAddress={emailAddress as string} />
-      <AddressesContainer shipToDifferentAddress={shipToDifferentAddress}>
+      <AddressesContainer
+        shipToDifferentAddress={shipToDifferentAddress}
+        isBusiness={isBusiness}
+      >
         <AddressSectionTitle data-testid="billing-address">
           <>{t(`addressForm.billing_address_title`)}</>
         </AddressSectionTitle>
@@ -198,6 +203,8 @@ export const CheckoutCustomerAddresses: React.FC<Props> = ({
                     <BillingAddressFormNew
                       billingAddress={billingAddressFill}
                       openShippingAddress={openShippingAddress}
+                      isBusiness={isBusiness}
+                      toggleIsBusiness={() => setIsBusiness(!isBusiness)}
                     />
                     <AddressFormBottom
                       addressType="billing"

--- a/components/ui/Toggle/index.tsx
+++ b/components/ui/Toggle/index.tsx
@@ -6,6 +6,7 @@ interface Props {
   checked: boolean
   onChange: () => void
   className?: string
+  wrapperClassName?: string
   disabled: boolean
 }
 
@@ -14,11 +15,12 @@ export const Toggle: React.FC<Props> = ({
   checked,
   onChange,
   className,
+  wrapperClassName,
   disabled,
   ...rest
 }) => {
   return (
-    <Wrapper>
+    <Wrapper className={wrapperClassName}>
       <ButtonToggle className={className} checked={checked}>
         <ButtonTrack
           disabled={disabled}

--- a/public/static/locales/de/common.json
+++ b/public/static/locales/de/common.json
@@ -113,9 +113,11 @@
   
     "addressForm": {
         "customer_email": "Deine E-Mail-Adresse",
+        "toggle_company_address": "Firmenname verwenden",
         "billing_address_title": "Rechnungsadresse",
         "billing_address_first_name": "Vorname",
         "billing_address_last_name": "Nachname",
+        "billing_address_company": "Name des Unternehmens",
         "billing_address_line_1": "Straße + Hausnummer",
         "billing_address_line_2": "Weitere Adressangaben",
         "billing_address_city": "Stadt",

--- a/public/static/locales/en/common.json
+++ b/public/static/locales/en/common.json
@@ -113,9 +113,11 @@
 
     "addressForm" : {
         "customer_email" : "Your email address",
+        "toggle_company_address": "Use company name",
         "billing_address_title": "Billing Address",
         "billing_address_first_name": "First name",
         "billing_address_last_name": "Last name",
+        "billing_address_company": "Company name",
         "billing_address_line_1": "Address line 1",
         "billing_address_line_2": "Address line 2",
         "billing_address_city": "City",

--- a/public/static/locales/it/common.json
+++ b/public/static/locales/it/common.json
@@ -113,9 +113,11 @@
 
     "addressForm" : {
         "customer_email" : "La tua email",
+        "toggle_company_address": "Sono un'Azienda",
         "billing_address_title": "Indirizzo di fatturazione",
         "billing_address_first_name": "Nome",
         "billing_address_last_name": "Cognome",
+        "billing_address_company": "Ragione sociale",
         "billing_address_line_1": "Indirizzo",
         "billing_address_line_2": "Presso",
         "billing_address_city": "Città",

--- a/public/static/locales/pl/common.json
+++ b/public/static/locales/pl/common.json
@@ -113,9 +113,11 @@
 
   "addressForm" : {
       "customer_email" : "Twój adres e-mail",
+      "toggle_company_address": "Użyj nazwy firmy",
       "billing_address_title": "Adres",
       "billing_address_first_name": "Imię",
       "billing_address_last_name": "Nazwisko",
+      "billing_address_company": "Nazwa firmy",
       "billing_address_line_1": "Adres linijka 1",
       "billing_address_line_2": "Adres linijka 2",
       "billing_address_city": "Miasto",


### PR DESCRIPTION
## What I did

I've added a toggle to enable the `business` flag in Address object, allowing customers to use a company name ("Ragione sociale") instead of first and last name; currently it's for billing only.

![immagine](https://github.com/commercelayer/mfe-checkout/assets/59646409/5045e805-7706-4d70-b008-c6c603860478)

The modifications act on the already predisposed **AddressesContainer** and **AddressInputGroup**.
Some ideas to improve the toggle:

- Better labels;
- Making the toggle optional (hidden by default);
- Adding toggle to Shipping Address too (it may be necessary to split the `AddressesContainer`s?)
- I'm not sure about the UI either. Maybe it would be better _outside_ the form area?

## How to test

1. Activate the toggle
2. Insert company name
3. Submit the address

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
