### PR TITLE
Skip errors if order is placed and redirect to thank you page

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "commercelayer"
   ],
   "dependencies": {
-    "@commercelayer/react-components": "^4.8.6",
+    "@commercelayer/react-components": "^4.9.0-beta.1",
     "@commercelayer/sdk": "^5.26.0",
     "@faker-js/faker": "^8.3.1",
     "@headlessui/react": "^1.7.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ overrides:
 
 dependencies:
   '@commercelayer/react-components':
-    specifier: ^4.8.6
-    version: 4.8.6(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^4.9.0-beta.1
+    version: 4.9.0-beta.1(react-dom@18.2.0)(react@18.2.0)
   '@commercelayer/sdk':
     specifier: ^5.26.0
     version: 5.26.0
@@ -581,8 +581,8 @@ packages:
     dev: true
     optional: true
 
-  /@commercelayer/react-components@4.8.6(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-7f0yuUiekTA4lnhj1msBVEZT/5eb3hGi0fdlg4Y0eggJSGVnfL6Jm2AC+QRa/l5JasF3b+WcJ4sHUeQQ92ilPw==}
+  /@commercelayer/react-components@4.9.0-beta.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-4f78u7QaMq0n91ecO4Mu7i4og/pu1e0YcsgRh8YnUl850zHGYeLXYnhXGTnidMuRNbMyN6yoqMP8aLb0vN1X4w==}
     peerDependencies:
       react: ^18.0.0
     dependencies:

--- a/specs/fixtures/CheckoutPage.ts
+++ b/specs/fixtures/CheckoutPage.ts
@@ -706,10 +706,11 @@ export class CheckoutPage {
           await phone.focus()
           await this.page.waitForTimeout(2000)
           await phone.fill("+393282243727")
-          await newPage.getByTestId("kaf-button").click()
+          await newPage.waitForTimeout(3000)
         }
 
         await newPage.locator("#otp_field__container input").fill("123456")
+        // await newPage.getByTestId("kaf-button").click()
         await newPage.getByTestId("select-payment-category").click()
         await newPage.getByTestId("pick-plan").click()
         await newPage.getByTestId("confirm-and-pay").click()


### PR DESCRIPTION
Closes #419 

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This PR will avoid to keep the customer in the checkout flow if the order is placed, sending the customer to the thank you page even if errors occur after placing the order.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
