### PR TITLE
Use `customer_address` id as address reference

### DIFF
--- a/components/data/AppProvider/utils.ts
+++ b/components/data/AppProvider/utils.ts
@@ -154,10 +154,10 @@ export async function checkAndSetDefaultAddressForOrder({
 
   // Set reference on original address if not present
   // doing this we can lookup the cloned address for the same entity
-  if (address.id && address.reference !== address.id) {
+  if (address.id && address.reference !== customerAddresses[0].id) {
     await cl.addresses.update({
       id: address.id,
-      reference: address.id,
+      reference: customerAddresses[0].id,
     })
   }
 
@@ -186,7 +186,7 @@ export async function checkAndSetDefaultAddressForOrder({
       customerAddresses: [
         {
           ...customerAddresses[0],
-          address: { ...address, reference: address.id },
+          address: { ...address, reference: customerAddresses[0].id },
         },
       ],
       hasSameAddresses: true,

--- a/specs/e2e/payments-paypal.spec.ts
+++ b/specs/e2e/payments-paypal.spec.ts
@@ -40,3 +40,34 @@ test.describe("guest with Paypal", () => {
     await checkoutPage.checkPaymentRecap("PayPal")
   })
 })
+
+test.describe("digital products with Paypal", () => {
+  const customerEmail = faker.internet.email().toLocaleLowerCase()
+  test.use({
+    defaultParams: {
+      order: "digital",
+      orderAttributes: {
+        customer_email: customerEmail,
+      },
+    },
+  })
+
+  test("Checkout order", async ({ checkoutPage }) => {
+    await checkoutPage.checkOrderSummary("Order Summary")
+
+    await checkoutPage.setBillingAddress()
+
+    await checkoutPage.save("Customer")
+
+    await checkoutPage.checkStep("Shipping", "not_present")
+
+    await checkoutPage.setPayment("paypal")
+
+    await checkoutPage.save("Payment", "Paga con PayPal")
+
+    await checkoutPage.checkPaymentRecap("PayPal")
+    await checkoutPage.page.reload()
+
+    await checkoutPage.checkPaymentRecap("PayPal")
+  })
+})

--- a/specs/fixtures/tokenizedPage.ts
+++ b/specs/fixtures/tokenizedPage.ts
@@ -310,15 +310,16 @@ const getOrder = async (
           const a = await customerCl.addresses.create({
             ...address,
           } as AddressCreate)
-          await customerCl.addresses.update({
-            id: a.id,
-            reference: a.id,
-          })
           // @ts-expect-error sdf
-          return customerCl.customer_addresses.create({
+          const ca = await customerCl.customer_addresses.create({
             customer: customerCl.customers.relationship(id),
             address: customerCl.addresses.relationship(a),
           })
+          await customerCl.addresses.update({
+            id: a.id,
+            reference: ca.id,
+          })
+          return ca
         })
         await Promise.all(promises)
       }


### PR DESCRIPTION
Closes #433 

This PR will use the `customer_address` id when autoselecting the single customer address to automatically link it to the order.

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

<!-- Briefly describe what your PR does -->

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
