### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
 name: Release
+permissions:
+  contents: write
+  statuses: write
 on:
   push:
     branches: [main, beta, alpha]


### PR DESCRIPTION
Closes #522 

Potential fix for [https://github.com/commercelayer/mfe-checkout/security/code-scanning/3](https://github.com/commercelayer/mfe-checkout/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level (root) to define the least privileges required. Based on the workflow's steps:
- The `actions/checkout` step requires `contents: read` to fetch the repository code.
- The `semantic-release` step may require additional permissions, such as `contents: write` to create releases and `statuses: write` to update commit statuses.

We will start with the minimal permissions required for the workflow to function correctly and adjust as needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
