### PR TITLE
Improve scroll to top on thankyou page and mobile improvement on place order

### DIFF
--- a/components/composite/StepComplete/index.tsx
+++ b/components/composite/StepComplete/index.tsx
@@ -2,7 +2,7 @@ import PaymentSource from "@commercelayer/react-components/payment_source/Paymen
 import PaymentSourceBrandIcon from "@commercelayer/react-components/payment_source/PaymentSourceBrandIcon"
 import PaymentSourceBrandName from "@commercelayer/react-components/payment_source/PaymentSourceBrandName"
 import PaymentSourceDetail from "@commercelayer/react-components/payment_source/PaymentSourceDetail"
-import { useContext, useEffect, useState } from "react"
+import { useContext, useEffect, useRef } from "react"
 import { Trans, useTranslation } from "react-i18next"
 
 import { OrderSummary } from "components/composite/OrderSummary"
@@ -59,12 +59,21 @@ export const StepComplete: React.FC<Props> = ({
   const { t } = useTranslation()
 
   const ctx = useContext(AppContext)
+  const topRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
     if (thankyouPageUrl != null) {
       window.location.href = thankyouPageUrl
     }
   }, [thankyouPageUrl])
+
+  useEffect(() => {
+    if (topRef.current != null) {
+      topRef.current.scrollIntoView({
+        behavior: "smooth",
+      })
+    }
+  }, [topRef.current])
 
   if (!ctx) return null
 
@@ -77,7 +86,7 @@ export const StepComplete: React.FC<Props> = ({
   return (
     thankyouPageUrl == null && (
       <Base>
-        <Top>
+        <Top ref={topRef}>
           <Wrapper>
             <Logo
               logoUrl={logoUrl}

--- a/components/composite/StepPlaceOrder/styled.tsx
+++ b/components/composite/StepPlaceOrder/styled.tsx
@@ -47,7 +47,7 @@ export const StyledPlaceOrderButton = styled(
   CustomPlaceOrderButton,
 )<StyledPlaceOrderButtonProps>`
   ${ButtonCss}
-  ${({ isActive }) => (isActive ? null : tw`md:hidden`)}
+  ${({ isActive }) => (isActive ? null : tw`hidden`)}
 `
 export const StyledPrivacyAndTermsCheckbox = styled(PrivacyAndTermsCheckbox)`
   ${CheckCss}
@@ -55,7 +55,7 @@ export const StyledPrivacyAndTermsCheckbox = styled(PrivacyAndTermsCheckbox)`
 export const PlaceOrderButtonWrapper = styled(ButtonWrapper)`
   ${tw`fixed w-full bottom-9 p-5 bg-gray-50 z-20 border-t md:(static flex justify-end z-auto p-0 bg-white border-0)`}
   &::before {
-    ${tw`top-0 absolute left-0 w-full z-10 h-2 shadow-top md:hidden`}
+    ${tw`top-0 absolute left-0 w-full z-10 h-2 shadow-top hidden`}
 
     content: "";
   }

--- a/specs/e2e/guest-addresses.spec.ts
+++ b/specs/e2e/guest-addresses.spec.ts
@@ -53,12 +53,13 @@ test.describe("with customer email", () => {
   test("missing fields on billing address", async ({ checkoutPage }) => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
-    const { name, address } = faker
+    const { firstName, lastName } = faker.person
+    const { streetAddress } = faker.location
 
     const newAddress = {
-      first_name: name.firstName(),
-      last_name: name.lastName(),
-      line_1: address.streetAddress(),
+      first_name: firstName(),
+      last_name: lastName(),
+      line_1: streetAddress(),
     }
     await checkoutPage.setBillingAddress(newAddress)
 
@@ -242,7 +243,7 @@ test.describe("with customer email and shipping country code lock", () => {
     await checkoutPage.checkShipToDifferentAddressEnabled(false)
 
     const element = checkoutPage.page.locator(
-      "[data-testid=input_shipping_address_country_code]"
+      "[data-testid=input_shipping_address_country_code]",
     )
     expect(element).toBeDisabled()
     const shippingAddress = {
@@ -288,7 +289,7 @@ test.describe("with digital product and shipping country code lock", () => {
     await checkoutPage.selectCountry("billing_address", "FR")
     await checkoutPage.page.fill(
       "[data-testid=input_billing_address_state_code]",
-      "PA"
+      "PA",
     )
 
     await checkoutPage.isVisibleShipToDifferentAddress(false)
@@ -439,7 +440,7 @@ test.describe("email error validation", () => {
 
     await checkoutPage.page
       .locator(
-        "[data-testid=customer_email_error] >> text=Please enter a valid email"
+        "[data-testid=customer_email_error] >> text=Please enter a valid email",
       )
       .waitFor({ state: "visible" })
     await checkoutPage.setBillingAddress()
@@ -485,7 +486,7 @@ test.describe("email error validation", () => {
 
     await checkoutPage.page
       .locator(
-        "[data-testid=customer_email_error] >> text=Please enter a valid email"
+        "[data-testid=customer_email_error] >> text=Please enter a valid email",
       )
       .waitFor({ state: "visible" })
   })

--- a/specs/e2e/order-summary.spec.ts
+++ b/specs/e2e/order-summary.spec.ts
@@ -6,7 +6,7 @@ import { euAddress, usAddress } from "../utils/addresses"
 test.describe("with return to cart", () => {
   const customerEmail = faker.internet.email().toLocaleLowerCase()
 
-  const cartUrl = "https://www.google.it"
+  const cartUrl = "https://www.google.com"
   test.use({
     defaultParams: {
       order: "with-items",
@@ -117,24 +117,24 @@ test.describe("quantity and unit price", () => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
     let element = checkoutPage.page.locator(
-      "[data-testid=order-summary] >> text=Quantity: 5"
+      "[data-testid=order-summary] >> text=Quantity: 5",
     )
     await expect(element).toHaveText("QUANTITY: 5")
 
     element = checkoutPage.page.locator(
-      "[data-testid=order-summary] >> text=Quantity: 1"
+      "[data-testid=order-summary] >> text=Quantity: 1",
     )
     await expect(element).toHaveText("QUANTITY: 1")
 
     await checkoutPage.checkStep("Shipping", "open")
 
     element = checkoutPage.page.locator(
-      "[data-testid=shipments-container] >> text=Quantity: 5"
+      "[data-testid=shipments-container] >> text=Quantity: 5",
     )
     await expect(element).toHaveText("QUANTITY: 5")
 
     element = checkoutPage.page.locator(
-      "[data-testid=shipments-container] >> text=Quantity: 1"
+      "[data-testid=shipments-container] >> text=Quantity: 1",
     )
     await expect(element).toHaveText("QUANTITY: 1")
   })
@@ -253,7 +253,7 @@ test.describe("buying gift card", () => {
   test("should appear on summary", async ({ checkoutPage }) => {
     await checkoutPage.checkOrderSummary("Order Summary")
     const element = checkoutPage.page.locator(
-      "[data-testid=line-items-gift_cards] >> text=Gift card: €100,00"
+      "[data-testid=line-items-gift_cards] >> text=Gift card: €100,00",
     )
 
     await expect(element).toHaveCount(1)
@@ -265,7 +265,7 @@ test.describe("buying gift card", () => {
 test.describe("using gift card", () => {
   const customerEmail = faker.internet.email().toLocaleLowerCase()
   const phone = faker.phone.number()
-  const returnUrl = "https://www.google.it"
+  const returnUrl = "https://www.google.com"
 
   test.use({
     defaultParams: {
@@ -298,12 +298,12 @@ test.describe("using gift card", () => {
 
     await checkoutPage.checkGiftCardAmount("-€20,00")
     let element = checkoutPage.page.locator(
-      "[data-testid=line-items-gift_cards]"
+      "[data-testid=line-items-gift_cards]",
     )
     await expect(element).toHaveCount(0)
 
     element = checkoutPage.page.locator(
-      "[data-testid=items-count] >> text=Your shopping cart contains 3 items"
+      "[data-testid=items-count] >> text=Your shopping cart contains 3 items",
     )
     await expect(element).toHaveCount(1)
   })
@@ -312,7 +312,7 @@ test.describe("using gift card", () => {
 test.describe("with tax included", () => {
   const customerEmail = faker.internet.email().toLocaleLowerCase()
 
-  const cartUrl = "https://www.google.it"
+  const cartUrl = "https://www.google.com"
   test.use({
     defaultParams: {
       order: "with-items",
@@ -347,7 +347,7 @@ test.describe("with tax included", () => {
 test.describe("with tax not included", () => {
   const customerEmail = faker.internet.email().toLocaleLowerCase()
 
-  const cartUrl = "https://www.google.it"
+  const cartUrl = "https://www.google.com"
   test.use({
     defaultParams: {
       order: "with-items",
@@ -458,7 +458,7 @@ test.describe("count with only free items", () => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
     await checkoutPage.checkLineItemsCount(
-      "Your shopping cart contains 2 items"
+      "Your shopping cart contains 2 items",
     )
   })
 })
@@ -483,7 +483,7 @@ test.describe("count with mixed items", () => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
     await checkoutPage.checkLineItemsCount(
-      "Your shopping cart contains 5 items"
+      "Your shopping cart contains 5 items",
     )
   })
 })
@@ -505,7 +505,7 @@ test.describe("count using gift card", () => {
   test("should count the right items", async ({ checkoutPage }) => {
     await checkoutPage.checkOrderSummary("Order Summary")
     await checkoutPage.checkLineItemsCount(
-      "Your shopping cart contains 5 items"
+      "Your shopping cart contains 5 items",
     )
   })
 })

--- a/specs/e2e/payments-checkoutcom.spec.ts
+++ b/specs/e2e/payments-checkoutcom.spec.ts
@@ -35,7 +35,7 @@ test.describe("guest with checkout.com", () => {
 
     await checkoutPage.setPayment("checkout_com")
 
-    const element = await checkoutPage.page.locator(
+    const element = checkoutPage.page.locator(
       "[data-testid=payment-save-wallet]",
     )
     expect(element).not.toBeVisible()
@@ -53,7 +53,7 @@ test.describe("guest with checkout.com", () => {
       .click()
 
     await checkoutPage.page
-      .locator(`text=Thank you for your order!`)
+      .locator("text=Thank you for your order!")
       .waitFor({ state: "visible", timeout: 100000 })
 
     await checkoutPage.checkPaymentRecap("Visa ending in 4242")
@@ -100,9 +100,7 @@ test.describe("guest with checkout.com declined payment and retry", () => {
       cvc: "1234",
     })
 
-    let element = await checkoutPage.page.locator(
-      "[data-testid=payment-save-wallet]",
-    )
+    let element = checkoutPage.page.locator("[data-testid=payment-save-wallet]")
     expect(element).not.toBeVisible()
 
     await checkoutPage.save("Payment", undefined, true)
@@ -115,9 +113,7 @@ test.describe("guest with checkout.com declined payment and retry", () => {
 
     await checkoutPage.setPayment("checkout_com")
 
-    element = await checkoutPage.page.locator(
-      "[data-testid=payment-save-wallet]",
-    )
+    element = checkoutPage.page.locator("[data-testid=payment-save-wallet]")
     expect(element).not.toBeVisible()
 
     await checkoutPage.save("Payment", undefined, true)
@@ -181,7 +177,7 @@ test.describe("customer with checkout.com without saving", () => {
 
     await checkoutPage.setPayment("checkout_com")
 
-    const element = await checkoutPage.page.locator(
+    const element = checkoutPage.page.locator(
       "[data-testid=payment-save-wallet]",
     )
     expect(element).toBeVisible()
@@ -200,7 +196,7 @@ test.describe("customer with checkout.com without saving", () => {
       .click()
 
     await checkoutPage.page
-      .locator(`text=Thank you for your order!`)
+      .locator("text=Thank you for your order!")
       .waitFor({ state: "visible", timeout: 100000 })
 
     await checkoutPage.checkPaymentRecap("Visa ending in 4242")
@@ -243,15 +239,11 @@ test.describe("customer with checkout.com with saving", () => {
 
     await checkoutPage.setPayment("checkout_com")
 
-    let element = await checkoutPage.page.locator(
-      "[data-testid=payment-save-wallet]",
-    )
+    let element = checkoutPage.page.locator("[data-testid=payment-save-wallet]")
     expect(element).toBeVisible()
     expect(element).not.toBeChecked()
     await element.check()
-    element = await checkoutPage.page.locator(
-      "[data-testid=payment-save-wallet]",
-    )
+    element = checkoutPage.page.locator("[data-testid=payment-save-wallet]")
     expect(element).toBeChecked()
 
     await checkoutPage.save("Payment", undefined, true)
@@ -267,7 +259,7 @@ test.describe("customer with checkout.com with saving", () => {
       .click()
 
     await checkoutPage.page
-      .locator(`text=Thank you for your order!`)
+      .locator("text=Thank you for your order!")
       .waitFor({ state: "visible", timeout: 100000 })
 
     await checkoutPage.checkPaymentRecap("Visa ending in 4242")
@@ -287,6 +279,66 @@ test.describe("customer with checkout.com with saving", () => {
     await checkoutPage.useCustomerCard()
 
     await checkoutPage.save("Payment")
+
+    await checkoutPage.checkPaymentRecap("Visa ending in 4242")
+  })
+})
+
+test.skip("guest with checkout.com as single payment method", () => {
+  const customerEmail = faker.internet.email().toLocaleLowerCase()
+
+  test.use({
+    defaultParams: {
+      order: "with-items",
+      market: "PT",
+      orderAttributes: {
+        customer_email: customerEmail,
+      },
+      lineItemsAttributes: [
+        { sku_code: "CANVASAU000000FFFFFF1824", quantity: 1 },
+      ],
+      addresses: {
+        billingAddress: euAddress,
+        sameShippingAddress: true,
+      },
+    },
+  })
+
+  test("checkout", async ({ checkoutPage }) => {
+    await checkoutPage.checkOrderSummary("Order Summary")
+
+    await checkoutPage.checkStep("Shipping", "open")
+
+    await checkoutPage.selectShippingMethod({ text: "Standard Shipping" })
+
+    await checkoutPage.save("Shipping")
+
+    await checkoutPage.setPayment("checkout_com")
+
+    const element = checkoutPage.page.locator(
+      "[data-testid=payment-save-wallet]",
+    )
+    expect(element).not.toBeVisible()
+
+    await checkoutPage.save("Payment", undefined, true)
+
+    await checkoutPage.page
+      .frameLocator('iframe[name="cko-3ds2-iframe"]')
+      .locator("#password")
+      .fill("Checkout1!")
+
+    await checkoutPage.page
+      .frameLocator('iframe[name="cko-3ds2-iframe"]')
+      .locator("text=Continue")
+      .click()
+
+    await checkoutPage.page
+      .locator("text=Thank you for your order!")
+      .waitFor({ state: "visible", timeout: 100000 })
+
+    await checkoutPage.checkPaymentRecap("Visa ending in 4242")
+
+    await checkoutPage.page.reload()
 
     await checkoutPage.checkPaymentRecap("Visa ending in 4242")
   })

--- a/specs/fixtures/tokenizedPage.ts
+++ b/specs/fixtures/tokenizedPage.ts
@@ -29,7 +29,17 @@ type OrderType =
   | "gift-card"
   | "with-items"
 
-type ValidMarket = "EU" | "US" | "MI" | "MT" | "IT" | "IE" | "LP" | "UY" | "VV"
+type ValidMarket =
+  | "EU"
+  | "US"
+  | "MI"
+  | "MT"
+  | "IT"
+  | "IE"
+  | "LP"
+  | "UY"
+  | "VV"
+  | "PT"
 
 interface BaseLineItemObject {
   quantity: number


### PR DESCRIPTION
Closes #506 

## What I did

This PR will send the customer at the top of the thank you page once the order is placed.
We also apply the same desktop logic to the place order button on mobile.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
