### PR TITLE
Skip delivery step with default shipping method and one customer address

### DIFF
--- a/components/data/AppProvider/index.tsx
+++ b/components/data/AppProvider/index.tsx
@@ -123,13 +123,14 @@ export const AppProvider: React.FC<AppProviderProps> = ({
     dispatch({ type: ActionType.START_LOADING })
     const order = await getOrderFromRef()
 
-    const addressInfos = await checkAndSetDefaultAddressForOrder({
-      cl,
-      order,
-    })
+    const { shipments, ...addressInfos } =
+      await checkAndSetDefaultAddressForOrder({
+        cl,
+        order,
+      })
 
     const others = calculateSettings(
-      order,
+      shipments != null ? { ...order, shipments: shipments } : order,
       isShipmentRequired,
       isGuest,
       undefined,

--- a/components/data/AppProvider/utils.ts
+++ b/components/data/AppProvider/utils.ts
@@ -166,12 +166,14 @@ export async function checkAndSetDefaultAddressForOrder({
     _shipping_address_clone_id: address.id,
   }
   try {
-    const { billing_address, shipping_address } = await cl.orders.update(
-      updateObjet,
-      {
-        include: ["billing_address", "shipping_address"],
-      },
-    )
+    const { billing_address, shipping_address, shipments } =
+      await cl.orders.update(updateObjet, {
+        include: [
+          "billing_address",
+          "shipping_address",
+          "shipments.shipping_method",
+        ],
+      })
 
     localStorage.setItem(
       "_save_billing_address_to_customer_address_book",
@@ -195,6 +197,7 @@ export async function checkAndSetDefaultAddressForOrder({
       isUsingNewShippingAddress: false,
       billingAddress: billing_address,
       shippingAddress: shipping_address,
+      shipments,
     }
   } catch (error) {
     console.log(error)

--- a/specs/e2e/checkout-defaults.spec.ts
+++ b/specs/e2e/checkout-defaults.spec.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker"
 
-import { test, expect } from "../fixtures/tokenizedPage"
+import { test } from "../fixtures/tokenizedPage"
 import { euAddressNoBillingInfo } from "../utils/addresses"
 
 const customerEmail = faker.internet.email().toLocaleLowerCase()
@@ -19,12 +19,14 @@ test.describe("with single defaults", () => {
     },
   })
 
-  test("should execute a checkout with valid token", async ({ checkoutPage }) => {
+  test("should execute a checkout with valid token", async ({
+    checkoutPage,
+  }) => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
     await checkoutPage.setCustomerMail()
     await checkoutPage.checkCustomerAddressesTitle(
-      "Fill in your billing/shipping address"
+      "Fill in your billing/shipping address",
     )
     await checkoutPage.setBillingAddress(euAddressNoBillingInfo)
 
@@ -35,7 +37,7 @@ test.describe("with single defaults", () => {
     await checkoutPage.checkStep("Shipping", "close")
 
     await checkoutPage.checkShippingSummary("FREE")
- 
+
     await checkoutPage.checkStep("Payment", "open")
 
     await checkoutPage.save("Payment")
@@ -69,7 +71,7 @@ test.describe("with single defaults and customer", () => {
     await checkoutPage.checkStep("Shipping", "close")
 
     await checkoutPage.checkShippingSummary("FREE")
- 
+
     await checkoutPage.checkStep("Payment", "open")
 
     await checkoutPage.save("Payment")
@@ -91,12 +93,14 @@ test.describe("with multi shipping single payment defaults", () => {
     },
   })
 
-  test("should execute a checkout with valid token", async ({ checkoutPage }) => {
+  test("should execute a checkout with valid token", async ({
+    checkoutPage,
+  }) => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
     await checkoutPage.setCustomerMail()
     await checkoutPage.checkCustomerAddressesTitle(
-      "Fill in your billing/shipping address"
+      "Fill in your billing/shipping address",
     )
     await checkoutPage.setBillingAddress(euAddressNoBillingInfo)
 
@@ -117,7 +121,7 @@ test.describe("with multi shipping single payment defaults", () => {
     await checkoutPage.checkShippingSummary("10")
 
     await checkoutPage.checkStep("Payment", "open")
-    
+
     await checkoutPage.save("Payment")
     await checkoutPage.checkPaymentRecap("Manual Payment")
   })
@@ -136,12 +140,14 @@ test.describe("with multi shipping multi payment defaults", () => {
       },
       addresses: {
         billingAddress: euAddressNoBillingInfo,
-        sameShippingAddress: true
-      }
+        sameShippingAddress: true,
+      },
     },
   })
 
-  test("should execute a checkout with valid token", async ({ checkoutPage }) => {
+  test("should execute a checkout with valid token", async ({
+    checkoutPage,
+  }) => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
     await checkoutPage.checkStep("Customer", "close")
@@ -158,5 +164,43 @@ test.describe("with multi shipping multi payment defaults", () => {
 
     await checkoutPage.save("Payment")
     await checkoutPage.checkPaymentRecap("Visa ending in 4242")
+  })
+})
+
+test.describe("customer with address multi shipping single payment defaults", () => {
+  const customerEmail = faker.internet.email().toLocaleLowerCase()
+  const customerPassword = faker.internet.password()
+
+  test.use({
+    defaultParams: {
+      market: "UY",
+      order: "with-items",
+      lineItemsAttributes: [
+        { sku_code: "TSHIRTMS000000FFFFFFLXXX", quantity: 1 },
+      ],
+      customer: {
+        email: customerEmail,
+        password: customerPassword,
+      },
+      customerAddresses: [euAddressNoBillingInfo],
+      orderAttributes: {
+        customer_email: customerEmail,
+      },
+    },
+  })
+
+  test("should execute a checkout with valid token", async ({
+    checkoutPage,
+  }) => {
+    await checkoutPage.checkOrderSummary("Order Summary")
+
+    await checkoutPage.checkStep("Shipping", "close")
+
+    await checkoutPage.checkShippingSummary("FREE")
+
+    await checkoutPage.checkStep("Payment", "open")
+
+    await checkoutPage.save("Payment")
+    await checkoutPage.checkPaymentRecap("Manual Payment")
   })
 })


### PR DESCRIPTION
Closes #542 

## What I did

This PR will skip the delivery step when a customer token is used and the customer has one customer address.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
