### PR TITLE
Unable to save customer addresses with external payment provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@commercelayer/js-auth": "^6.7.2",
     "@commercelayer/organization-config": "^2.4.0",
-    "@commercelayer/react-components": "4.25.6-beta.0",
+    "@commercelayer/react-components": "4.25.6",
     "@commercelayer/sdk": "^6.45.0",
     "@faker-js/faker": "^9.9.0",
     "@headlessui/react": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@commercelayer/js-auth": "^6.7.2",
     "@commercelayer/organization-config": "^2.4.0",
-    "@commercelayer/react-components": "4.25.4",
+    "@commercelayer/react-components": "4.25.5",
     "@commercelayer/sdk": "^6.45.0",
     "@faker-js/faker": "^9.9.0",
     "@headlessui/react": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@commercelayer/js-auth": "^6.7.2",
     "@commercelayer/organization-config": "^2.4.0",
-    "@commercelayer/react-components": "4.25.5",
+    "@commercelayer/react-components": "4.25.6-beta.0",
     "@commercelayer/sdk": "^6.45.0",
     "@faker-js/faker": "^9.9.0",
     "@headlessui/react": "^2.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0
       '@commercelayer/react-components':
-        specifier: 4.25.5
-        version: 4.25.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(typescript@5.8.3)
+        specifier: 4.25.6-beta.0
+        version: 4.25.6-beta.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(typescript@5.8.3)
       '@commercelayer/sdk':
         specifier: ^6.45.0
         version: 6.45.0
@@ -411,8 +411,8 @@ packages:
     resolution: {integrity: sha512-65r3YS3GssircqSyScQhKNXWm4iN5eegA7u/FUhD+5Ny+X1kq/CylzysQmZ+HR3UciMhDFIV0BvATaAZuJVPEw==}
     engines: {node: '>=18', pnpm: '>=7'}
 
-  '@commercelayer/react-components@4.25.5':
-    resolution: {integrity: sha512-uaExCYZEWcJLpdjjUOg9shUYHDbEelQnUbebHeJJFMD1WLgXtPP7P6YpXwzwmvLLkNWw0uMNYxzsxZyYeflqGg==}
+  '@commercelayer/react-components@4.25.6-beta.0':
+    resolution: {integrity: sha512-p4klrZqnMKTuy1EJVvlw2JZXYnun3mpZhrVw6OOVWKNHgXKg7vIWc6e40HuhmuehoHFHuQsCqjSSjtEDjkfO3A==}
     peerDependencies:
       react: '>=18.0.0'
 
@@ -3508,7 +3508,7 @@ snapshots:
     dependencies:
       merge-anything: 5.1.7
 
-  '@commercelayer/react-components@4.25.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(typescript@5.8.3)':
+  '@commercelayer/react-components@4.25.6-beta.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(typescript@5.8.3)':
     dependencies:
       '@adyen/adyen-web': 6.17.0
       '@commercelayer/organization-config': 2.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0
       '@commercelayer/react-components':
-        specifier: 4.25.6-beta.0
-        version: 4.25.6-beta.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(typescript@5.8.3)
+        specifier: 4.25.6
+        version: 4.25.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(typescript@5.8.3)
       '@commercelayer/sdk':
         specifier: ^6.45.0
         version: 6.45.0
@@ -411,8 +411,8 @@ packages:
     resolution: {integrity: sha512-65r3YS3GssircqSyScQhKNXWm4iN5eegA7u/FUhD+5Ny+X1kq/CylzysQmZ+HR3UciMhDFIV0BvATaAZuJVPEw==}
     engines: {node: '>=18', pnpm: '>=7'}
 
-  '@commercelayer/react-components@4.25.6-beta.0':
-    resolution: {integrity: sha512-p4klrZqnMKTuy1EJVvlw2JZXYnun3mpZhrVw6OOVWKNHgXKg7vIWc6e40HuhmuehoHFHuQsCqjSSjtEDjkfO3A==}
+  '@commercelayer/react-components@4.25.6':
+    resolution: {integrity: sha512-VJMCLtBUKYb0SoV3PavQw1GBA36b6/WFe9bUIFpNkJZ54v7ViAL1UxSB6lwEAi9N9H03v42z5TjvMqaAGVBmLw==}
     peerDependencies:
       react: '>=18.0.0'
 
@@ -3508,7 +3508,7 @@ snapshots:
     dependencies:
       merge-anything: 5.1.7
 
-  '@commercelayer/react-components@4.25.6-beta.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(typescript@5.8.3)':
+  '@commercelayer/react-components@4.25.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(typescript@5.8.3)':
     dependencies:
       '@adyen/adyen-web': 6.17.0
       '@commercelayer/organization-config': 2.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^2.4.0
         version: 2.4.0
       '@commercelayer/react-components':
-        specifier: 4.25.4
-        version: 4.25.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(typescript@5.8.3)
+        specifier: 4.25.5
+        version: 4.25.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(typescript@5.8.3)
       '@commercelayer/sdk':
         specifier: ^6.45.0
         version: 6.45.0
@@ -411,8 +411,8 @@ packages:
     resolution: {integrity: sha512-65r3YS3GssircqSyScQhKNXWm4iN5eegA7u/FUhD+5Ny+X1kq/CylzysQmZ+HR3UciMhDFIV0BvATaAZuJVPEw==}
     engines: {node: '>=18', pnpm: '>=7'}
 
-  '@commercelayer/react-components@4.25.4':
-    resolution: {integrity: sha512-AFYx9OsPRPO/oAxm37XAixNyX8LfDFESzvGk46PTrD4RsQS7JTrlOAXxhOoOlpVWyiPBK+t68F8SjNXAEEa2Sg==}
+  '@commercelayer/react-components@4.25.5':
+    resolution: {integrity: sha512-uaExCYZEWcJLpdjjUOg9shUYHDbEelQnUbebHeJJFMD1WLgXtPP7P6YpXwzwmvLLkNWw0uMNYxzsxZyYeflqGg==}
     peerDependencies:
       react: '>=18.0.0'
 
@@ -3508,7 +3508,7 @@ snapshots:
     dependencies:
       merge-anything: 5.1.7
 
-  '@commercelayer/react-components@4.25.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(typescript@5.8.3)':
+  '@commercelayer/react-components@4.25.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.31.0)(typescript@5.8.3)':
     dependencies:
       '@adyen/adyen-web': 6.17.0
       '@commercelayer/organization-config': 2.4.0

--- a/specs/e2e/customer-addresses-with-wallet.spec.ts
+++ b/specs/e2e/customer-addresses-with-wallet.spec.ts
@@ -157,7 +157,7 @@ test.describe("address on wallet and payment with checkout.com", () => {
     },
   })
 
-  test.skip("save one address on wallet", async ({ checkoutPage }) => {
+  test("save one address on wallet", async ({ checkoutPage }) => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
     await checkoutPage.setBillingAddress(euAddress)
@@ -197,7 +197,7 @@ test.describe("address on wallet and payment with checkout.com", () => {
       .waitFor({ state: "visible", timeout: 100000 })
   })
 
-  test.skip("use address on wallet", async ({ checkoutPage }) => {
+  test("use address on wallet", async ({ checkoutPage }) => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
     await checkoutPage.checkStep("Customer", "close")
@@ -224,7 +224,7 @@ test.describe("address on wallet and payment with adyen and klarna", () => {
     },
   })
 
-  test.skip("save one address on wallet", async ({ checkoutPage }) => {
+  test("save one address on wallet", async ({ checkoutPage }) => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
     await checkoutPage.setBillingAddress(euAddress2)
@@ -251,7 +251,7 @@ test.describe("address on wallet and payment with adyen and klarna", () => {
     await checkoutPage.checkPaymentRecap("Klarna ending in ****")
   })
 
-  test.skip("use address on wallet", async ({ checkoutPage }) => {
+  test("use address on wallet", async ({ checkoutPage }) => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
     await checkoutPage.checkStep("Customer", "close")
@@ -278,7 +278,7 @@ test.describe("address on wallet and payment with adyen and credit card", () => 
     },
   })
 
-  test.skip("save one address on wallet", async ({ checkoutPage }) => {
+  test("save one address on wallet", async ({ checkoutPage }) => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
     await checkoutPage.setBillingAddress(euAddress2)
@@ -304,7 +304,7 @@ test.describe("address on wallet and payment with adyen and credit card", () => 
     await checkoutPage.checkPaymentRecap(" ending in ****")
   })
 
-  test.skip("use address on wallet", async ({ checkoutPage }) => {
+  test("use address on wallet", async ({ checkoutPage }) => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
     await checkoutPage.checkStep("Customer", "close")
@@ -332,7 +332,7 @@ test.describe("address on wallet and payment with affirm", () => {
     },
   })
 
-  test.skip("success", async ({ checkoutPage }) => {
+  test("success", async ({ checkoutPage }) => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
     await checkoutPage.setBillingAddress(usAddress)
@@ -362,11 +362,12 @@ test.describe("address on wallet and payment with affirm", () => {
     await checkoutPage.checkPaymentRecap("Affirm ending in ****", 10000)
   })
 
-  test.skip("use address on wallet", async ({ checkoutPage }) => {
+  test("use address on wallet", async ({ checkoutPage }) => {
     await checkoutPage.checkOrderSummary("Order Summary")
 
     await checkoutPage.checkStep("Customer", "close")
-    await checkoutPage.checkStep("Shipping", "open")
+    await checkoutPage.checkStep("Shipping", "close")
+    await checkoutPage.checkStep("Payment", "open")
   })
 })
 

--- a/specs/e2e/thank-you-page.spec.ts
+++ b/specs/e2e/thank-you-page.spec.ts
@@ -306,17 +306,16 @@ test.describe("with custom thankyou page url @organization-config", () => {
 
     await checkoutPage.save("Payment", undefined, true)
 
-    await checkoutPage.page.waitForTimeout(3000)
+    await expect(checkoutPage.page.getByText("200 OK")).toHaveCount(1)
 
-    await checkoutPage.checkContinueShoppingLink("not_present")
+    const thankyouPageReplaced = thankyouPageUrl
+      .replace(":order_id", checkoutPage.getOrderId() as string)
+      .replace(":access_token", checkoutPage.getAccessToken() as string)
 
-    const url = checkoutPage.page.url()
-
-    expect(url).toMatch(
-      thankyouPageUrl
-        .replace(":order_id", checkoutPage.getOrderId() as string)
-        .replace(":access_token", checkoutPage.getAccessToken() as string),
-    )
+    await checkoutPage.page.waitForURL(thankyouPageReplaced, {
+      timeout: 10000,
+      waitUntil: "commit",
+    })
   })
 })
 
@@ -360,19 +359,18 @@ test.describe("with custom thankyou page url @organization-config and token", ()
 
     await checkoutPage.save("Payment", undefined, true)
 
-    await checkoutPage.page.waitForTimeout(3000)
+    await expect(checkoutPage.page.getByText("200 OK")).toHaveCount(1)
 
-    await checkoutPage.checkContinueShoppingLink("not_present")
+    const thankyouPageReplaced = thankyouPageUrl
+      .replace(":lang", "it-IT")
+      .replace(":order_id", checkoutPage.getOrderId() as string)
+      .replace(":token", checkoutPage.getOrderToken() as string)
+      .replace(":slug", process.env.NEXT_PUBLIC_SLUG as string)
 
-    const url = checkoutPage.page.url()
-
-    expect(url).toMatch(
-      thankyouPageUrl
-        .replace(":lang", "it-IT")
-        .replace(":order_id", checkoutPage.getOrderId() as string)
-        .replace(":token", checkoutPage.getOrderToken() as string)
-        .replace(":slug", process.env.NEXT_PUBLIC_SLUG as string),
-    )
+    await checkoutPage.page.waitForURL(thankyouPageReplaced, {
+      timeout: 10000,
+      waitUntil: "commit",
+    })
   })
 })
 


### PR DESCRIPTION
Closes #554 

## What I did

This PR will fix the issue related to save customer addresses when the customer goes to a third party website during payment.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
