### PR TITLE
Avoid a redirect to the thankyou page url if present on expired pending orders

### DIFF
--- a/components/composite/StepExpired/index.tsx
+++ b/components/composite/StepExpired/index.tsx
@@ -16,7 +16,6 @@ interface Props {
 export const StepExpired: React.FC<Props> = ({
   logoUrl,
   companyName,
-  thankyouPageUrl = null,
   expirationInfo,
 }) => {
   const { t } = useTranslation()
@@ -24,12 +23,6 @@ export const StepExpired: React.FC<Props> = ({
   const ctx = useContext(AppContext)
   const topRef = useRef<HTMLDivElement | null>(null)
   const returnExpireUrl = expirationInfo?.return_url || ctx?.returnUrl
-
-  useEffect(() => {
-    if (thankyouPageUrl != null) {
-      window.location.href = thankyouPageUrl
-    }
-  }, [thankyouPageUrl])
 
   useEffect(() => {
     if (topRef.current != null) {


### PR DESCRIPTION
Closes #576 

## What I did

This PR will fix the behaviour of checkout with expired pending orders and a thankyou page URL on the organization config for the market.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
