### PR TITLE
fix(tests): update Stripe payment selector to handle non-button tab elements

### DIFF
--- a/specs/fixtures/CheckoutPage.ts
+++ b/specs/fixtures/CheckoutPage.ts
@@ -1320,24 +1320,22 @@ export class CheckoutPage {
       "[data-testid=stripe_payments] iframe",
     )
 
-    // Wait until the button is visible on the Stripe frame
+    // Wait until the Stripe iframe renders the payment method label (button or generic tab)
     await expect(async () => {
-      const button = stripeFrameLocator.getByRole("button", {
-        name: label,
-      })
-      await expect(button).toBeVisible()
+      await expect(
+        stripeFrameLocator.getByText(label, { exact: true }),
+      ).toBeVisible()
     }).toPass()
 
     await this.page.mouse.wheel(0, 300)
 
+    // Stripe may render tabs as <button> elements or as generic elements depending on
+    // how many payment methods are available. Click only when it is a button.
     const cardButton = stripeFrameLocator.getByRole("button", {
       name: label,
     })
     if (await cardButton.isVisible()) {
-      // Click the card button if it is visible
       await cardButton.click({ force: true })
-    } else {
-      throw new Error(`Payment method ${method} is not available`)
     }
     return stripeFrameLocator
   }


### PR DESCRIPTION
Close #619

## What

Stripe's Payment Element changed the rendering of payment method tabs from `<button>` elements to generic `<div>` elements. This caused `selectStripePaymentMethod` to time out when waiting for `getByRole('button', { name: label })`.

## Why

The `toPass()` assertion using `getByRole('button')` would never resolve because Stripe now renders the selected tab (e.g. "Card") as a plain text node inside a generic element — not a button. The page snapshot confirms `generic [ref=f5e17]: Card` rather than a `button`.

## Changes

- `specs/fixtures/CheckoutPage.ts`: replaced the wait condition from `getByRole('button', { name: label })` to `getByText(label, { exact: true })` to match the label regardless of its HTML element type.
- The click step now silently skips when no button is found — when Stripe pre-selects a payment method (e.g. Card), the form is already visible and no click is required. Other methods (PayPal, Affirm, Klarna) still render as buttons and will be clicked normally.
