### PR TITLE
fix: defer setOrder to avoid render-phase state update warning

### DIFF
--- a/components/data/AppProvider/index.tsx
+++ b/components/data/AppProvider/index.tsx
@@ -113,7 +113,11 @@ export const AppProvider: React.FC<AppProviderProps> = ({
 
   const getOrder = (order: Order) => {
     orderRef.current = order
-    setOrder(order)
+    // OrderContainer (react-components) invokes this callback during render,
+    // so defer the state update to avoid a render-phase setState warning.
+    setTimeout(() => {
+      setOrder(order)
+    }, 0)
   }
 
   const fetchInitialOrder = async (orderId?: string, accessToken?: string) => {

--- a/specs/fixtures/CheckoutPage.ts
+++ b/specs/fixtures/CheckoutPage.ts
@@ -1327,14 +1327,23 @@ export class CheckoutPage {
       ).toBeVisible()
     }).toPass()
 
-    await this.page.mouse.wheel(0, 300)
-
     // Stripe may render tabs as <button> elements or as generic elements depending on
     // how many payment methods are available. Click only when it is a button.
     const cardButton = stripeFrameLocator.getByRole("button", {
       name: label,
     })
     if (await cardButton.isVisible()) {
+      const box = await cardButton.boundingBox()
+      const viewport = this.page.viewportSize()
+      if (
+        box != null &&
+        viewport != null &&
+        box.y + box.height > viewport.height
+      ) {
+        // Element inside the cross-origin Stripe iframe is below the fold:
+        // Playwright can't scroll the outer page for it, so do it ourselves.
+        await this.page.mouse.wheel(0, box.y + box.height - viewport.height + 100)
+      }
       await cardButton.click({ force: true })
     }
     return stripeFrameLocator


### PR DESCRIPTION
## What

- **`AppProvider.getOrder`**: `OrderContainer` (from `@commercelayer/react-components`) invokes the `getOrder` callback during render, so calling `setOrder` synchronously triggered React's "Cannot update a component while rendering a different component" warning. The state update is now deferred with `setTimeout(..., 0)`; `orderRef` is still set synchronously so consumers reading the ref are unaffected.
- **`CheckoutPage.ts` (e2e fixture)**: replaced the fixed `mouse.wheel(0, 300)` scroll with a conditional one — the Stripe payment tab lives in a cross-origin iframe, so Playwright can't auto-scroll the outer page for it. The fixture now measures the tab's bounding box and scrolls only when it's below the fold, just enough to bring it into view.

## Why

The render-phase `setState` warning polluted the console on every order load and can mask real issues. The blind 300px scroll made the Stripe tab click flaky depending on viewport size and page layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)